### PR TITLE
Use the s2i-thoth-f32-py38-cloc base image

### DIFF
--- a/openshift/buildConfig.yaml
+++ b/openshift/buildConfig.yaml
@@ -90,7 +90,7 @@ objects:
         sourceStrategy:
           from:
             kind: ImageStreamTag
-            name: s2i-thoth-ubi8-py36:latest
+            name: s2i-thoth-f32-py38-cloc:latest
           env:
             - name: ENABLE_PIPENV
               value: "1"


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

The s2i-thoth-f32-py38-cloc base image would be used for the si-cloc project. 

